### PR TITLE
Adding Currency field for donation form testing

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,6 +6,7 @@ site_side: true
 tags: london
 level: 3
 region: Europe
+currency: GBP
 
 ---
 <!-- rebuild -->


### PR DESCRIPTION
Donation and Membership forms are getting migrated to the new site. We are in test mode right now and one parameter we can pass to the form is currency so the donation form doesn't look so US-centric. BTW once we get into production we will also be passing title of the page so donors can choose to be listed as supporters of a chapter/project. More details on that later but no changes needed on your end for that feature.