### PR TITLE
Don't deploy README.md

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,9 @@
 remote_theme: "owasp/www--site-theme@main"
+
+# core files/folders to exclude
+exclude:
+  - README.md
+
 plugins:
  - jekyll-include-cache-0.2.0
+ 


### PR DESCRIPTION
README.md doesn't need to be deployed to owasp.org/www-chapter-london/README.md