### PR TITLE
2022 11 17 post event cleanup

### DIFF
--- a/index.md
+++ b/index.md
@@ -202,17 +202,8 @@ Call For Speakers is open - if you would like to present a talk on Application S
 Next Meeting/Event(s)
 ---------------------
 
-
-##### Thursday, 8th September 2022 (in-person/hybrid)
-Live-Stream: https://www.youtube.com/OWASPLondon
-
-Lightning Talk: “Using Trivy and Falco to Detect Malware in a Kubernetes Environment” - Marco Mancini
-
-Talk 1: “The Iceberg: Your Attack Surface Just Got Bigger (How to mitigate risks in your OSS projects)” - Sonya Moisset
-
-Talk 2: “Pwning the CI Workflow and How to Prevent It “- Steve Giguere
-
-Full Details and Registration: https://www.eventbrite.co.uk/e/owasp-london-chapter-in-person-meetup-tickets-407116214557
+[//]: # (Comment: When updating the next event info also update the next event tab)
+##### To Be Confirmed 
 
 OWASP London Chapter meetings are posted on our MeetUp Page:
 

--- a/tab_nextevent.md
+++ b/tab_nextevent.md
@@ -10,22 +10,8 @@ tags: london
 ---
 
 ## Next Meeting/Event(s)
-
-#### Thursday, 17th November 2022 (in-person/hybrid)
-The next OWASP London Chapter in-person meetup will take place on Thursday 17th November 2022 at Amazon Prime Video London HQ.
-
-TALKS
-
-* Talk 1: "Securing DevOps: Where to Start and What to Measure?" - Stefania Chaplin
-
-* Talk 2: "Will FIDO Passkey help us to move on from Passwords?" - Dario Salice
-
-REGISTRATION:
-
-You can register to attend this event here:
-
-[https://www.eventbrite.co.uk/e/owasp-london-chapter-in-person-meetup-tickets-456117428507?aff=ws](https://www.eventbrite.co.uk/e/owasp-london-chapter-in-person-meetup-tickets-456117428507?aff=ws)
-
+[//]: # (Comment: When updating the next event info also update the homepage)
+### To Be Confirmed
 
 ---
 Please follow OWASP London on [Twitter](https://twitter.com/owasplondon)/[Facebook](https://www.facebook.com/OWASPLondon)/[Meetup](https://www.meetup.com/OWASP-London/)/[EventBrite](https://www.eventbrite.co.uk/o/owasp-london-chapter-9790101329) or join our [Mailing List](https://groups.google.com/a/owasp.org/forum/#!forum/london-chapter) to be notified as soon as the next event date & location is announced

--- a/tab_nextevent.md
+++ b/tab_nextevent.md
@@ -10,6 +10,7 @@ tags: london
 ---
 
 ## Next Meeting/Event(s)
+
 [//]: # (Comment: When updating the next event info also update the homepage)
 ### To Be Confirmed
 

--- a/tab_pastevents.md
+++ b/tab_pastevents.md
@@ -11,6 +11,31 @@ tags: london
 
 ## Past Events
 
+#### Thursday, 17th November 2022 (in-person/hybrid)
+
+Video recording: [https://www.youtube.com/watch?v=W-rsFfAF5IE&t=1070s]
+
+* Intro: Welcome and a brief update on OWASP Projects & Events from the OWASP London Chapter Leaders
+* Talk 1: "Securing DevOps: Where to Start and What to Measure?" - Stefania Chaplin
+* Talk 2: "Will FIDO Passkey help us to move on from Passwords?" - Dario Salice
+
+Talk 1: "Securing DevOps: Where to Start and What to Measure?" - Stefania Chaplin
+
+How do we secure our DevOps processes? Why is shifting left important? How do we get developers to care about security and empower them to make a difference? Where do we start and what do we measure? Often in software development we operate in silos. Different tribes have different priorities and lexicons. How do we break down these preexisting silos and continue innovating and optimising our software development process? Shifting left can help to break down silos and empower developers to take a security first approach. Measuring DevOps can be hard, DORA metrics can help you to become an Elite performer. Join this session to find out more about these and importantly, when it comes to securing DevOps where to start and what to measure.
+
+Talk 2: "Will FIDO Passkey help us to move on from Passwords?" - Dario Salice
+
+Passwords are bad at protecting our digital assets and they make it harder for us to access them. Security: An estimated 22% of US consumers self-identify as having been hacked at least once. A hacked account sells for as little as $1. Access: Forgetting your password seems like merely an annoyance. However, it contributes to churn on consumer platforms and can make up 50% of corporate IT Support calls. All is not lost; Passkey is here to save the day. In this session, I’ll walk you through what passkey is, how it works, and how it can impact your churn and security goals.
+
+SPEAKERS: 
+Stefania Chaplin, Solutions Architect at Gitlab.
+
+Stefania’s experience as a Solutions Architect within Cybersecurity, DevSecOps and OSS governance means she's helped countless organisations understand and implement security throughout their SDLC. She is an active member of OWASP DevSlop, hosting their technical shows. When not at a computer, Stefania enjoys surfing, yoga and looking after all her tropical plants.
+
+Dario Salice
+
+Dario Salice is a seasoned professional in the space of Telecommunications, Security, and Online-Identities. While most recently working at Google and then Meta, he provided the right security tools to billions of users to protect their online accounts. Dario also launched programs to protect highly targeted individuals from attack. Serving as Meta’s representative on the Board of the FIDO Alliance, an industry standards organization working on strong authentication methods, Dario gained a broader perspective on the global authentication market. His current focus is ramping up an independent boutique consulting service to engage with companies of any size who want to benefit from his insights and experience in the Security & Identity space.
+
 #### Thursday, 8th September 2022 (in-person/hybrid)
 
 Video recodrings: [https://www.youtube.com/watch?v=bDB1IvhtmWI](https://youtube.com/playlist?list=PLmfxTKOjvC_f91Ex8ZJfH56lO7GG-dyG4)

--- a/tab_pastevents.md
+++ b/tab_pastevents.md
@@ -13,7 +13,7 @@ tags: london
 
 #### Thursday, 17th November 2022 (in-person/hybrid)
 
-Video recording: [https://www.youtube.com/watch?v=W-rsFfAF5IE&t=1070s]
+Video recording: [https://www.youtube.com/playlist?list=PLmfxTKOjvC_e8X_C9vj69ckFy2GJ8qi6j]
 
 * Intro: Welcome and a brief update on OWASP Projects & Events from the OWASP London Chapter Leaders
 * Talk 1: "Securing DevOps: Where to Start and What to Measure?" - Stefania Chaplin


### PR DESCRIPTION
I've pushed the recent event to the past events page.

I've also added a comment on the homepage and next next event tab referencing each other as the last event (17th Nov) got missed from the home page (was showing 8th Nov)!