### PR TITLE
Improve link formatting and fix brand spelling

### DIFF
--- a/index.md
+++ b/index.md
@@ -237,6 +237,6 @@ Please [SUBSCRIBE](https://www.youtube.com/OWASPLondon?sub_confirmation=1) to ou
 
 Updates on Social Media and Mailing List
 ---------------------
-Please follow OWASP London Chapter on <a href="https://twitter.com/OWASPLondon">Twiter</a>/<a href="https://facebook.com/OWASPLondon">Facebook</a>/<a href="https://meetup.com/OWASP-London">MeetUp</a>/<a href="https://owasplondon.eventbrite.com">EventBrite</a>/<a href="https://www.linkedin.com/company/owasplondon">LinkedIN</a> and <a href="https://groups.google.com/a/owasp.org/forum/#!forum/london-chapter/join">sign up to our mailing list</a> to be notified about the upcoming OWASP London Chapter events.
+Please follow OWASP London Chapter on <a href="https://twitter.com/OWASPLondon">Twiter</a>/<a href="https://facebook.com/OWASPLondon">Facebook</a>/<a href="https://meetup.com/OWASP-London">MeetUp</a>/<a href="https://owasplondon.eventbrite.com">EventBrite</a>/<a href="https://www.linkedin.com/company/owasplondon">LinkedIn</a> and <a href="https://groups.google.com/a/owasp.org/forum/#!forum/london-chapter/join">sign up to our mailing list</a> to be notified about the upcoming OWASP London Chapter events.
 
 ---

--- a/index.md
+++ b/index.md
@@ -231,7 +231,7 @@ Please visit <a href="http://www.meetup.com/OWASP-London">http://www.meetup.com/
 
 Video Recordings of Past Events
 --------------------------------
-You can watch the recordings of talks presented at OWASP London events on our YouTube channel: https://www.youtube.com/OWASPLondon
+You can watch the recordings of talks presented at OWASP London events on our YouTube channel: [https://www.youtube.com/OWASPLondon](https://www.youtube.com/OWASPLondon)
 
 Please [SUBSCRIBE](https://www.youtube.com/OWASPLondon?sub_confirmation=1) to our YouTube channel to get notified when new videos get published.
 


### PR DESCRIPTION
Hi! 

I hope this meets the expected guidelines. I have made the following improvements to the London chapter homepage:

1. YouTube link formatting, wrapped the raw text URL in a Markdown anchor so it generates a proper hyperlink, resolving mobile responsiveness and tap-target issues while keeping the full URL visible.
2. LinkedIn brand spelling, corrected the capitalisation of "LinkedIN" to "LinkedIn" across the page for consistency and standard branding.

Thank you!