### PR TITLE
moved July 16 2026 event to Past events

### DIFF
--- a/tab_nextevent.md
+++ b/tab_nextevent.md
@@ -13,24 +13,6 @@ tags: london
 
 [//]: # (Comment: When updating the next event info also update the homepage)
 
-#### Thursday, 16 July 2026 6:00pm (in-person/hybrid)
-
-The next OWASP London Chapter in-person meetup will take place on July 16, 2026, 6pm.
-
-TALKS:
-
-* "Steal the Session, Skip the Login: How Real Attacks Move from Session Replay to Broken AuthZ and MCP Abuse" - Viola Lykova
-
-* "Testing LLM Application in the Real World" - Donato Capitella
-
-REGISTRATION:
-
-
-Register to attend this event here:
-
-[https://www.eventbrite.co.uk/e/owasp-london-chapter-meetup-in-person-tickets-1993451949443](https://www.eventbrite.co.uk/e/owasp-london-chapter-meetup-in-person-tickets-1993451949443?aff=ws)
-
-
 
 ---
 Please follow OWASP London on [Twitter](https://twitter.com/owasplondon)/[Facebook](https://www.facebook.com/OWASPLondon)/[Meetup](https://www.meetup.com/OWASP-London/)/[EventBrite](https://www.eventbrite.co.uk/o/owasp-london-chapter-9790101329)/[LinkedIn](https://linkedin.com/in/company/owasplondon)/[BlueSky](https://owasplondon.bsky.social)/[Mastodon](https://infosec.exchange/@owasplondon) or join our [Mailing List](https://groups.google.com/a/owasp.org/forum/#!forum/london-chapter) to be notified as soon as the next event date & location is announced

--- a/tab_pastevents.md
+++ b/tab_pastevents.md
@@ -11,6 +11,26 @@ tags: london
 
 ## Past Events
 
+#### Thursday, 16 July 2026 6:00pm (in-person/hybrid)
+
+The next OWASP London Chapter in-person meetup will take place on July 16, 2026, 6pm.
+
+TALKS:
+
+* "Steal the Session, Skip the Login: How Real Attacks Move from Session Replay to Broken AuthZ and MCP Abuse" - Viola Lykova
+
+* "Testing LLM Application in the Real World" - Donato Capitella
+
+REGISTRATION:
+
+
+Register to attend this event here:
+
+[https://www.eventbrite.co.uk/e/owasp-london-chapter-meetup-in-person-tickets-1993451949443](https://www.eventbrite.co.uk/e/owasp-london-chapter-meetup-in-person-tickets-1993451949443?aff=ws)
+
+Video Recordings: YouTube [playlist](https://www.youtube.com/playlist?list=PLHvDMwBOzaLI)
+
+
 #### Tuesday, 30 June 2026 6:00pm (in-person/hybrid)
 
 The next OWASP London Chapter in-person meetup will take place on June 30, 2026


### PR DESCRIPTION
moved July 16 2026 event to Past events 

OWASP London July 16 2026 talks video recordings playlist added: 
https://www.youtube.com/playlist?list=PLHvDMwBOzaLI